### PR TITLE
Price added to ProductView.xaml

### DIFF
--- a/Grocery.App/Views/ProductView.xaml
+++ b/Grocery.App/Views/ProductView.xaml
@@ -4,47 +4,67 @@
              xmlns:vm="clr-namespace:Grocery.App.ViewModels"
              x:Class="Grocery.App.Views.ProductView"
              Title="ProductView">
-    
+
     <Shell.TitleView>
         <Grid>
             <Label Text="Producten" FontSize="Large" HorizontalOptions="Center" VerticalOptions="Center" />
         </Grid>
     </Shell.TitleView>
 
-    <Border Stroke="#C49B33" StrokeThickness="4" Padding="10" Margin="10" HorizontalOptions="Center">
-        <CollectionView ItemsSource="{Binding Products}" Margin="20" HorizontalOptions="Center">
+    <!-- Border vult nu volledige breedte -->
+    <Border Stroke="#C49B33" StrokeThickness="4" Padding="10" Margin="10" HorizontalOptions="Fill">
+        <CollectionView ItemsSource="{Binding Products}" Margin="20" HorizontalOptions="Fill">
             <CollectionView.ItemsLayout>
                 <LinearItemsLayout Orientation="Vertical" ItemSpacing="10" />
             </CollectionView.ItemsLayout>
+
+            <!-- Header -->
             <CollectionView.Header>
-                <Grid>
+                <Grid HorizontalOptions="Fill">
                     <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="3*"/>
-                        <ColumnDefinition Width="2*"/>
-                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="3*" />
+                        <ColumnDefinition Width="2*" />
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="*" />
                     </Grid.ColumnDefinitions>
                     <Label Text="Naam van het product" Grid.Column="0" FontAttributes="Bold"/>
                     <Label Text="Voorraad" Grid.Column="1" HorizontalTextAlignment="End" FontAttributes="Bold"/>
                     <Label Text="THT datum" Grid.Column="2" HorizontalTextAlignment="End" FontAttributes="Bold"/>
+                    <Label Text="Prijs" Grid.Column="3" HorizontalTextAlignment="End" FontAttributes="Bold"/>
                 </Grid>
             </CollectionView.Header>
+
+            <!-- Items -->
             <CollectionView.ItemTemplate>
                 <DataTemplate>
                     <Grid>
                         <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="3*"/>
-                            <ColumnDefinition Width="2*"/>
-                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="3*" />
+                            <ColumnDefinition Width="2*" />
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="*" />
                         </Grid.ColumnDefinitions>
-                        <Label Grid.Column="0" Text="{Binding Name}"/>
-                        <Label Grid.Column="1" Text="{Binding Stock, StringFormat='{}{0:F0} op voorraad'}" HorizontalOptions="End">
+
+                        <Label Grid.Column="0" Text="{Binding Name}" VerticalOptions="Center"/>
+
+                        <Label Grid.Column="1"
+                               Text="{Binding Stock, StringFormat='{}{0:F0} op voorraad'}"
+                               HorizontalOptions="End"
+                               VerticalOptions="Center">
                             <Label.Triggers>
                                 <DataTrigger TargetType="Label" Binding="{Binding Stock}" Value="0">
-                                    <Setter Property="Text" Value="niet op voorraad" />
+                                    <Setter Property="Text" Value="niet op voorraad"/>
+                                    <Setter Property="TextColor" Value="Red"/>
                                 </DataTrigger>
                             </Label.Triggers>
                         </Label>
-                        <Label Grid.Column="2" Text="{Binding ShelfLife}" HorizontalOptions="End"/>
+
+                        <Label Grid.Column="2" Text="{Binding ShelfLife}" HorizontalOptions="End" VerticalOptions="Center"/>
+
+                        <Label Grid.Column="3"
+                               Text="{Binding Price, StringFormat='€{0:N2}'}"
+                               HorizontalOptions="End"
+                               VerticalOptions="Center"/>
                     </Grid>
                 </DataTemplate>
             </CollectionView.ItemTemplate>


### PR DESCRIPTION
**UC14 – Product List View**

This update adds UC14, which shows a list of products with:

Name, stock, shelf life, and price in columns.

Prices displayed as €{0:N2}.

Stock of 0 shown as “niet op voorraad” in red.

Header and columns aligned so everything is visible.

This makes it easier for users to see product details, price, and availability at a glance.